### PR TITLE
Remove parallel disk state evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "libredfish 0.1.0 (git+https://github.com/cholcombe973/libredfish)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lvm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lvm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mocktopus 0.5.0 (git+https://github.com/asomers/Mocktopus.git?branch=get_type_id)",
  "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "lvm"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3070,7 +3070,7 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum lvm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "475bc8f67c82acc9aca384ee15604910a546f5cefea8755a65f1f8060ea20be2"
+"checksum lvm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8433cb98a3ebee4069b7f9e2faa91fc232a8c4c9d721f4eca2cf7628bec1c9a1"
 "checksum lvm-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1d4b235a603c00a497762f086a3f63470171b1103586159363f2265c9ffd5919"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"

--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -103,7 +103,7 @@ fn listen(
 
     debug!("Listening on tcp://{}:5555", listen_address);
     // Fail to start if this fails
-    setup_curve(&mut responder, config_dir, vault).unwrap();
+    setup_curve(&mut responder, config_dir, vault)?;
     assert!(responder
         .bind(&format!("tcp://{}:5555", listen_address))
         .is_ok());
@@ -491,8 +491,12 @@ fn main() {
         }
     }
     let log = Path::new(matches.value_of("log").unwrap());
-    let backend = BackendType::from_str(matches.value_of("backend").unwrap()).unwrap();
-    let vault_support = { bool::from_str(matches.value_of("vault").unwrap()).unwrap() };
+    let backend = BackendType::from_str(matches.value_of("backend").unwrap())
+        .expect("unable to convert backend option to BackendType");
+    let vault_support = {
+        bool::from_str(matches.value_of("vault").unwrap())
+            .expect("unable to convert vault option to bool")
+    };
     let mut loggers: Vec<Box<dyn SharedLogger>> = vec![];
     if let Some(term_logger) = TermLogger::new(level, Config::default()) {
         //systemd doesn't use a terminal

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -63,8 +63,8 @@ pub fn add_disk_request(
     o.set_Op_type(Op::Add);
     o.set_disk(format!("{}", path.display()));
     o.set_simulate(simulate);
-    if id.is_some() {
-        o.set_osd_id(id.unwrap());
+    if let Some(id) = id {
+        o.set_osd_id(id);
     }
 
     let encoded = o.write_to_bytes().unwrap();


### PR DESCRIPTION
Lvm has a bug where instantiating more than 1 LVM instance causes the program to segfault.  rust-gdb has narrowed this down to the lvm_init function but I don't know anything further. I suspect LVM was never designed to be used like this.  I also changed a few unwraps to either expect's or ? to try and get better error messages when things go wrong.  