### PR TITLE
Bring ZMQ to 0.8 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ tempdir = "~0.3"
 time = "~0.1"
 uname = "~0.1"
 uuid = { version="~0.7", features = ["v4"]}
-zmq = {version="~0.9"}
+zmq = {version="~0.8"}
 
 [lib]
 name = "helpers"

--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -84,7 +84,6 @@ fn setup_curve(s: &Socket, config_dir: &Path, vault: bool) -> BynarResult<()> {
         debug!("Creating new curve keypair");
         s.set_curve_secretkey(&keypair.secret_key)?;
         let mut f = File::create(key_file)?;
-        debug!("public key {:?}", &keypair.public_key);
         f.write_all(keypair.public_key.as_bytes())?;
     }
     debug!("Server mechanism: {:?}", s.get_mechanism());

--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -77,14 +77,15 @@ fn setup_curve(s: &Socket, config_dir: &Path, vault: bool) -> BynarResult<()> {
         let client = VaultClient::new(endpoint.as_str(), token)?;
         client.set_secret(
             format!("{}/{}.pem", config_dir.display(), hostname),
-            String::from_utf8_lossy(&keypair.public_key),
+            String::from_utf8_lossy(keypair.public_key.as_bytes()),
         )?;
         s.set_curve_secretkey(&keypair.secret_key)?;
     } else {
         debug!("Creating new curve keypair");
         s.set_curve_secretkey(&keypair.secret_key)?;
         let mut f = File::create(key_file)?;
-        f.write_all(&keypair.public_key)?;
+        debug!("public key {:?}", &keypair.public_key);
+        f.write_all(keypair.public_key.as_bytes())?;
     }
     debug!("Server mechanism: {:?}", s.get_mechanism());
     debug!("Curve server: {:?}", s.is_curve_server());
@@ -247,7 +248,7 @@ fn listen(
 fn respond_to_client<T: protobuf::Message>(result: &T, s: &Socket) -> BynarResult<()> {
     let encoded = result.write_to_bytes()?;
     debug!("Responding to client with msg len: {}", encoded.len());
-    s.send(encoded, 0)?;
+    s.send(&encoded, 0)?;
     Ok(())
 }
 
@@ -349,7 +350,7 @@ fn list_disks(s: &Socket) -> BynarResult<()> {
     let encoded = disks.write_to_bytes()?;
 
     debug!("Responding to client with msg len: {}", encoded.len());
-    s.send(encoded, 0)?;
+    s.send(&encoded, 0)?;
     Ok(())
 }
 
@@ -412,13 +413,13 @@ fn safe_to_remove_disk(
             result.set_error_msg(e.to_string());
             let encoded = result.write_to_bytes()?;
             debug!("Responding to client with msg len: {}", encoded.len());
-            s.send(encoded, 0)?;
+            s.send(&encoded, 0)?;
             return Err(BynarError::new(format!("safe to remove error: {}", e)));
         }
     };
     let encoded = result.write_to_bytes()?;
     debug!("Responding to client with msg len: {}", encoded.len());
-    s.send(encoded, 0)?;
+    s.send(&encoded, 0)?;
     Ok(())
 }
 

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -32,16 +32,11 @@ where
 pub fn connect(host: &str, port: &str, server_publickey: &str) -> BynarResult<Socket> {
     debug!("Starting zmq sender with version({:?})", zmq::version());
     let context = zmq::Context::new();
-    debug!("Created Context");
     let requester = context.socket(zmq::REQ)?;
-    debug!("Create new REQUESTER");
     let client_keypair = zmq::CurveKeyPair::new()?;
-    debug!("Create new keypair");
-    debug!("server public key {:?}", server_publickey);
+    debug!("Created new keypair");
     requester.set_curve_serverkey(server_publickey)?;
-    debug!("ServerKey Set");
     requester.set_curve_publickey(&client_keypair.public_key)?;
-    debug!("Public Key Set");
     requester.set_curve_secretkey(&client_keypair.secret_key)?;
     debug!("Connecting to tcp://{}:{}", host, port);
     assert!(requester

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -32,11 +32,16 @@ where
 pub fn connect(host: &str, port: &str, server_publickey: &str) -> BynarResult<Socket> {
     debug!("Starting zmq sender with version({:?})", zmq::version());
     let context = zmq::Context::new();
+    debug!("Created Context");
     let requester = context.socket(zmq::REQ)?;
+    debug!("Create new REQUESTER");
     let client_keypair = zmq::CurveKeyPair::new()?;
-
-    requester.set_curve_serverkey(server_publickey.as_bytes())?;
+    debug!("Create new keypair");
+    debug!("server public key {:?}", server_publickey);
+    requester.set_curve_serverkey(server_publickey)?;
+    debug!("ServerKey Set");
     requester.set_curve_publickey(&client_keypair.public_key)?;
+    debug!("Public Key Set");
     requester.set_curve_secretkey(&client_keypair.secret_key)?;
     debug!("Connecting to tcp://{}:{}", host, port);
     assert!(requester
@@ -70,7 +75,7 @@ pub fn add_disk_request(
 
     let encoded = o.write_to_bytes().unwrap();
     debug!("Sending message");
-    s.send(encoded, 0)?;
+    s.send(&encoded, 0)?;
 
     debug!("Waiting for response");
     let add_response = s.recv_bytes(0)?;
@@ -125,7 +130,7 @@ pub fn list_disks_request(s: &Socket) -> BynarResult<Vec<Disk>> {
     debug!("{:?}", encoded);
 
     debug!("Sending message");
-    s.send(encoded, 0)?;
+    s.send(&encoded, 0)?;
 
     debug!("Waiting for response");
     let disks_response = s.recv_bytes(0)?;
@@ -147,7 +152,7 @@ pub fn safe_to_remove_request(s: &Socket, path: &Path) -> BynarResult<bool> {
     o.set_disk(format!("{}", path.display()));
     let encoded = o.write_to_bytes()?;
     debug!("Sending message");
-    s.send(encoded, 0)?;
+    s.send(&encoded, 0)?;
 
     debug!("Waiting for response");
     let safe_response = s.recv_bytes(0)?;
@@ -176,7 +181,7 @@ pub fn remove_disk_request(
 
     let encoded = o.write_to_bytes()?;
     debug!("Sending message");
-    s.send(encoded, 0)?;
+    s.send(&encoded, 0)?;
 
     debug!("Waiting for response");
     let remove_response = s.recv_bytes(0)?;
@@ -243,7 +248,7 @@ pub fn get_jira_tickets(s: &Socket) -> BynarResult<()>{
     o.set_Op_type(Op::GetCreatedTickets);
     let encoded = o.write_to_bytes()?;
     debug!("Sending message in get_jira_tickets");
-    s.send(encoded, 0)?;
+    s.send(&encoded, 0)?;
 
     debug!("Waiting for response: get_jira_tickets");
     let tickets_response = s.recv_bytes(0)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use r2d2_postgres::PostgresConnectionManager as ConnectionManager;
 use simplelog::{CombinedLogger, Config, SharedLogger, TermLogger, WriteLogger};
 use slack_hook::{PayloadBuilder, Slack};
 use std::fs::{create_dir, read_to_string, File};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 /*#[derive(Clone, Debug, Deserialize)]
@@ -111,6 +112,7 @@ fn get_public_key(config: &ConfigSettings, host_info: &Host) -> BynarResult<Stri
         if !p.exists() {
             error!("{} does not exist", p.display());
         }
+        debug!("Reading public key from {:?}", p);
         let key = read_to_string(p)?;
         Ok(key)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,6 @@ fn get_public_key(config: &ConfigSettings, host_info: &Host) -> BynarResult<Stri
         if !p.exists() {
             error!("{} does not exist", p.display());
         }
-        debug!("Reading public key from {:?}", p);
         let key = read_to_string(p)?;
         Ok(key)
     }


### PR DESCRIPTION
Reverting ZMQ back to ~0.8 because CurveKeyPair in 0.9 up is now in binary format instead of z85-encoded representation