### PR TITLE
Add Unmounts and Mounts where necessary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rand = "~0.7"
 [dependencies]
 api = { path = "api" }
 blkid = "~0.2"
-block-utils = "~0.6"
+block-utils = {git = "https://github.com/cholcombe973/block-utils"} #"~0.6"
 bytes = "*"
 ceph = "~3.0"
 chrono = "~0.4"

--- a/src/test_disk.rs
+++ b/src/test_disk.rs
@@ -16,8 +16,8 @@ use crate::in_progress::{
 };
 use blkid::BlkId;
 use block_utils::{
-    format_block_device, get_device_info, mount_device, unmount_device, Device, DeviceState,DeviceType,
-    Filesystem, FilesystemType, MediaType, ScsiDeviceType, ScsiInfo, Vendor,
+    format_block_device, get_device_info, mount_device, unmount_device, Device, DeviceState,
+    DeviceType, Filesystem, FilesystemType, MediaType, ScsiDeviceType, ScsiInfo, Vendor,
 };
 use gpt::{disk, header::read_header, partition::read_partitions, partition::Partition};
 use helpers::{error::*, host_information::Host};
@@ -378,12 +378,12 @@ impl Transition for AttemptRepair {
                         }
                     }
                     to_state
-                },
+                }
                 Err(e) => {
                     error!("repair_filesystem failed on {:?}: {}", device, e);
                     // This requires root perms.  If the filesystem was previously mounted remount the filesystem
                     if let Some(ref mnt) = device.mount_point {
-                        if !is_device_mounted(&device.dev_path){
+                        if !is_device_mounted(&device.dev_path) {
                             // attempted to remount the filesystem
                             if let Err(e) = mount_device(&device.device, &mnt) {
                                 error!("Remounting {} failed: {}", device.dev_path.display(), e);
@@ -411,17 +411,42 @@ impl Transition for CheckForCorruption {
             process::id()
         );
         if !simulate {
+            // keep ref to mountpoint.  check if filesystem unmounted (if not unmount first)
+            // After running check remount filesystem if unmounted
+            if let Some(ref mnt) = device.mount_point {
+                debug!("Attempt to unmount filesystem for checking");
+                if let Err(e) = unmount_device(&mnt) {
+                    error!("unmount {} failed: {}", mnt.display(), e);
+                };
+            }
             match check_filesystem(&device.device.fs_type, &device.dev_path) {
-                Ok(fsck) => match fsck {
-                    // Writes are failing but fsck is ok?
-                    // What else could be wrong?  The filesystem could be read only
-                    // or ??
-                    Fsck::Ok => State::Fail,
-                    // The filesystem is corrupted.  Proceed to repair
-                    Fsck::Corrupt => to_state,
-                },
+                Ok(fsck) => {
+                    // This requires root perms.  If the filesystem was previously mounted remount the filesystem
+                    if let Some(ref mnt) = device.mount_point {
+                        if let Err(e) = mount_device(&device.device, &mnt) {
+                            error!("Remounting {} failed: {}", device.dev_path.display(), e);
+                        }
+                    }
+                    match fsck {
+                        // Writes are failing but fsck is ok?
+                        // What else could be wrong?  The filesystem could be read only
+                        // or ??
+                        Fsck::Ok => State::Fail,
+                        // The filesystem is corrupted.  Proceed to repair
+                        Fsck::Corrupt => to_state,
+                    }
+                }
                 Err(e) => {
                     error!("check_filesystem failed on {:?}: {}", device, e);
+                    // This requires root perms.  If the filesystem was previously mounted remount the filesystem
+                    if let Some(ref mnt) = device.mount_point {
+                        if !is_device_mounted(&device.dev_path) {
+                            // attempted to remount the filesystem
+                            if let Err(e) = mount_device(&device.device, &mnt) {
+                                error!("Remounting {} failed: {}", device.dev_path.display(), e);
+                            }
+                        }
+                    }
                     State::Fail
                 }
             }
@@ -539,8 +564,9 @@ impl Transition for Eval {
                         error!("unmount {} failed: {}", device.dev_path.display(), e);
                     };
 
-                    let mountpoint = block_utils::get_mountpoint(&device.dev_path).expect("Failed to get mountpoint");
-                    debug!("Mountpoint after cleaning: {:?}", mountpoint); 
+                    let mountpoint = block_utils::get_mountpoint(&device.dev_path)
+                        .expect("Failed to get mountpoint");
+                    debug!("Mountpoint after cleaning: {:?}", mountpoint);
                 }
                 device.mount_point = None;
                 to_state
@@ -553,8 +579,9 @@ impl Transition for Eval {
                         error!("unmount {} failed: {}", device.dev_path.display(), e);
                     };
 
-                    let mountpoint = block_utils::get_mountpoint(&device.dev_path).expect("Failed to get mountpoint");
-                    debug!("Mountpoint after cleaning: {:?}", mountpoint); 
+                    let mountpoint = block_utils::get_mountpoint(&device.dev_path)
+                        .expect("Failed to get mountpoint");
+                    debug!("Mountpoint after cleaning: {:?}", mountpoint);
                 }
                 error!("Error writing to disk: {:?}", e);
                 State::WriteFailed
@@ -742,19 +769,18 @@ impl Transition for Scan {
         match (raid_backed.0, raid_backed.1) {
             (false, _) => match run_smart_checks(&Path::new(&device.dev_path)) {
                 Ok(stat) => {
-                    // If the device is a Disk, then end the state machine here. 
+                    // If the device is a Disk, then end the state machine here.
                     if device.device.device_type == DeviceType::Disk {
                         if stat {
                             debug!("Disk is healthy");
                             return State::Good;
-                        }
-                        else {
+                        } else {
                             debug!("Disk Health Scan Failed");
                             return State::Fail;
                         }
                     }
                     to_state
-                },
+                }
                 Err(e) => {
                     error!("Smart test failed: {:?}", e);
                     State::Fail
@@ -771,7 +797,7 @@ impl Transition for Scan {
                     Some(state) => {
                         debug!("thread {} scsi device state: {}", process::id(), state);
                         if *state == DeviceState::Running {
-                            // If the device is a Disk, then end the state machine here. 
+                            // If the device is a Disk, then end the state machine here.
                             if device.device.device_type == DeviceType::Disk {
                                 debug!("Disk is Healthy");
                                 return State::Good;
@@ -852,7 +878,7 @@ impl StateMachine {
             self.block_device.dev_path.display(),
             self.block_device.state
         );
-        if self.block_device.state == State::Good{
+        if self.block_device.state == State::Good {
             debug!("Starting state is Good, replacing with Unscanned");
             self.block_device.state = State::Unscanned;
         }
@@ -1758,8 +1784,8 @@ fn is_disk_blank(dev: &Path) -> BynarResult<bool> {
     match mount_device(&device, &mnt_dir.path()) {
         Ok(_) => {
             unmount_device(&mnt_dir.path())?;
-            return Ok(false)
-        },
+            return Ok(false);
+        }
         Err(e) => {
             debug!(
                 "thread {} Mounting {} failed: {}",
@@ -1768,7 +1794,7 @@ fn is_disk_blank(dev: &Path) -> BynarResult<bool> {
                 e
             );
             //If the partition is EMPTY, it should be mountable, which means if it ISN'T mountable its probably corrupt (and not blank)
-            return Ok(false)
+            return Ok(false);
         }
     }
 

--- a/src/test_disk.rs
+++ b/src/test_disk.rs
@@ -859,6 +859,10 @@ impl StateMachine {
                     self.block_device.state,
                     beginning_state
                 );
+                // Note: if the loop is state::Good, then rescan
+                if self.block_device.state == State::Good {
+                    self.block_device.state = State::Unscanned;
+                }
                 break 'outer;
             }
         }
@@ -982,7 +986,7 @@ impl StateMachine {
             "MarkForReplacement",
         );
 
-        self.add_transition(State::Repaired, State::Good, NoOp::transition, "NoOp");
+        self.add_transition(State::Repaired, State::Unscanned, NoOp::transition, "NoOp");
         self.add_transition(
             State::WaitingForReplacement,
             State::Replaced,


### PR DESCRIPTION
Some functions, such as fsck, xfs_repair, etc, require that the filesystem be unmounted first.  I have added unmounts to those functions as well as mounting them again (after an unmount).  There are also sometimes temporary mounts that need to get cleaned up