### PR TITLE
Ceph config filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ where to look for ceph configuration, user details etc.
 {
   "config_file": "/etc/ceph/ceph.conf",
   "user_id": "admin",
+  "boot_disks": [
+    {
+      "device": "/dev/sdc"
+    }
+  ],
   "journal_devices": [
 		{
 			"device": "/dev/sda"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ where to look for ceph configuration, user details etc.
 	]
 }
 ```
+Boot Disks must be specified for ceph to filter out.  A disk with the root or boot partition, as well
+as the device path of the root and boot (/boot, /boot/efi) partitions must be provided for Bynar to filter 
+out.  Bynar needs to be able to distinguish the disks so it does not try to wipe a boot partition.  If not
+provided ceph will attempt to add/remove the disk/partition as an OSD.  
+
 Journal devices can optionally be specified for ceph to use.  Bynar will attempt
 to balance the number of partitions across the devices given.  If an explict 
 `partition_id` is also given Bynar will make use of that.  If no `partition_id`

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ where to look for ceph configuration, user details etc.
 {
   "config_file": "/etc/ceph/ceph.conf",
   "user_id": "admin",
-  "boot_disks": [
+  "system_disks": [
     {
       "device": "/dev/sdc"
     }
@@ -118,7 +118,7 @@ where to look for ceph configuration, user details etc.
 	]
 }
 ```
-Boot Disks must be specified for ceph to filter out.  A disk with the root or boot partition, as well
+System Disks must be specified for ceph to filter out.  This is a list of all disks that Ceph should not run on.  A disk with the root or boot partition, as well
 as the device path of the root and boot (/boot, /boot/efi) partitions must be provided for Bynar to filter 
 out.  Bynar needs to be able to distinguish the disks so it does not try to wipe a boot partition.  If not
 provided ceph will attempt to add/remove the disk/partition as an OSD.  

--- a/api/protos/service.proto
+++ b/api/protos/service.proto
@@ -90,6 +90,21 @@ message OpStringResult {
   optional string error_msg = 3;
 }
 
+message OpEnumResult{
+  required ResultType result = 1;
+  optional OpEnum value = 2;
+  optional string error_msg = 3;
+}
+
+enum OpEnum {
+  // Operation Succeeded
+  Success = 1;
+  // Skipped this disk for some reason (boot disk, cannot run operation on specific device, etc.)
+  Skipped = 2;
+  // The operation has already been done on the disk
+  SkipRepeat = 3;
+}
+
 message  JiraInfo{
       required string ticket_id = 1;
       required string server_name = 2;

--- a/api/protos/service.proto
+++ b/api/protos/service.proto
@@ -90,13 +90,14 @@ message OpStringResult {
   optional string error_msg = 3;
 }
 
-message OpEnumResult{
+message OpOutcomeResult{
   required ResultType result = 1;
-  optional OpEnum value = 2;
-  optional string error_msg = 3;
+  optional OpOutcome outcome = 2;
+  optional bool value = 3;
+  optional string error_msg = 4;
 }
 
-enum OpEnum {
+enum OpOutcome {
   // Operation Succeeded
   Success = 1;
   // Skipped this disk for some reason (boot disk, cannot run operation on specific device, etc.)

--- a/api/protos/service.proto
+++ b/api/protos/service.proto
@@ -92,8 +92,11 @@ message OpStringResult {
 
 message OpOutcomeResult{
   required ResultType result = 1;
+  // outcome set if OK
   optional OpOutcome outcome = 2;
+  // value set if OK and needs to return a boolean
   optional bool value = 3;
+  // error_msg set if ERR
   optional string error_msg = 4;
 }
 

--- a/config/ceph.json
+++ b/config/ceph.json
@@ -1,7 +1,7 @@
 {
 	"config_file": "/etc/ceph/ceph.conf",
 	"user_id": "admin",
-	"boot_disks": [
+	"system_disks": [
 		{
 			"device": "/dev/sdc"
 		}

--- a/config/ceph.json
+++ b/config/ceph.json
@@ -1,6 +1,11 @@
 {
 	"config_file": "/etc/ceph/ceph.conf",
 	"user_id": "admin",
+	"boot_disks": [
+		{
+			"device": "/dev/sdc"
+		}
+	],
 	"journal_devices": [
 		{
 			"device": "/dev/sda"

--- a/src/backend/ceph.rs
+++ b/src/backend/ceph.rs
@@ -112,8 +112,9 @@ struct CephConfig {
     config_file: String,
     /// The cephx user to connect to the Ceph service with
     user_id: String,
-    /// The /dev/xxx devices that have one of the /, /boot, or /boot/efi partitions
-    /// Bynar will need to skip evaluation on those disks
+    /// The /dev/xxxx devices that have one of the /, /boot, or /boot/efi partitions
+    /// This includes the partitions that are /, /boot, or /boot/efi
+    /// Bynar will need to skip evaluation on those disks and partitions
     boot_disks: Vec<BootDisk>,
     /// The /dev/xxx devices to use for journal partitions.
     /// Bynar will create new partitions on these devices as needed

--- a/src/backend/gluster.rs
+++ b/src/backend/gluster.rs
@@ -24,14 +24,14 @@ pub struct GlusterBackend;
 */
 
 impl Backend for GlusterBackend {
-    fn add_disk(&self, _device: &Path, _id: Option<u64>, _simulate: bool) -> BynarResult<()> {
-        Ok(())
+    fn add_disk(&self, _device: &Path, _id: Option<u64>, _simulate: bool) -> BynarResult<bool> {
+        Ok(true)
     }
 
     /// Remove a disk from a cluster
     /// If simulate is passed no action should be taken
-    fn remove_disk(&self, _device: &Path, _simulate: bool) -> BynarResult<()> {
-        Ok(())
+    fn remove_disk(&self, _device: &Path, _simulate: bool) -> BynarResult<bool> {
+        Ok(true)
     }
 
     /// Check if it's safe to remove a disk from a cluster

--- a/src/backend/gluster.rs
+++ b/src/backend/gluster.rs
@@ -1,4 +1,4 @@
-use crate::backend::Backend;
+use crate::backend::{Backend, OperationOutcome};
 
 use helpers::error::*;
 use std::path::Path;
@@ -24,21 +24,30 @@ pub struct GlusterBackend;
 */
 
 impl Backend for GlusterBackend {
-    fn add_disk(&self, _device: &Path, _id: Option<u64>, _simulate: bool) -> BynarResult<bool> {
-        Ok(true)
+    fn add_disk(
+        &self,
+        _device: &Path,
+        _id: Option<u64>,
+        _simulate: bool,
+    ) -> BynarResult<OperationOutcome> {
+        Ok(OperationOutcome::Success)
     }
 
     /// Remove a disk from a cluster
     /// If simulate is passed no action should be taken
-    fn remove_disk(&self, _device: &Path, _simulate: bool) -> BynarResult<bool> {
-        Ok(true)
+    fn remove_disk(&self, _device: &Path, _simulate: bool) -> BynarResult<OperationOutcome> {
+        Ok(OperationOutcome::Success)
     }
 
     /// Check if it's safe to remove a disk from a cluster
     /// If simulate is passed then this always returns true
     /// Take any actions needed with this call to figure out if a disk is safe
     /// to remove from the cluster.
-    fn safe_to_remove(&self, _device: &Path, _simulate: bool) -> BynarResult<bool> {
-        Ok(true)
+    fn safe_to_remove(
+        &self,
+        _device: &Path,
+        _simulate: bool,
+    ) -> BynarResult<(OperationOutcome, bool)> {
+        Ok((OperationOutcome::Success, true))
     }
 }

--- a/src/backend/gluster.rs
+++ b/src/backend/gluster.rs
@@ -1,4 +1,5 @@
-use crate::backend::{Backend, OperationOutcome};
+use crate::backend::Backend;
+use api::service::OpOutcome;
 
 use helpers::error::*;
 use std::path::Path;
@@ -29,25 +30,21 @@ impl Backend for GlusterBackend {
         _device: &Path,
         _id: Option<u64>,
         _simulate: bool,
-    ) -> BynarResult<OperationOutcome> {
-        Ok(OperationOutcome::Success)
+    ) -> BynarResult<OpOutcome> {
+        Ok(OpOutcome::Success)
     }
 
     /// Remove a disk from a cluster
     /// If simulate is passed no action should be taken
-    fn remove_disk(&self, _device: &Path, _simulate: bool) -> BynarResult<OperationOutcome> {
-        Ok(OperationOutcome::Success)
+    fn remove_disk(&self, _device: &Path, _simulate: bool) -> BynarResult<OpOutcome> {
+        Ok(OpOutcome::Success)
     }
 
     /// Check if it's safe to remove a disk from a cluster
     /// If simulate is passed then this always returns true
     /// Take any actions needed with this call to figure out if a disk is safe
     /// to remove from the cluster.
-    fn safe_to_remove(
-        &self,
-        _device: &Path,
-        _simulate: bool,
-    ) -> BynarResult<(OperationOutcome, bool)> {
-        Ok((OperationOutcome::Success, true))
+    fn safe_to_remove(&self, _device: &Path, _simulate: bool) -> BynarResult<(OpOutcome, bool)> {
+        Ok((OpOutcome::Success, true))
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -11,25 +11,6 @@ use api::service::OpOutcome;
 use helpers::error::*;
 use serde_derive::*;
 
-/// The outcome of a Backend Operation
-pub enum OperationOutcome {
-    /// Operation Succeeded
-    Success,
-    /// Skipped this disk for some reason (boot disk, cannot run operation on specific device, etc.)
-    Skipped,
-    /// The operation has already been done on the disk
-    SkipRepeat,
-}
-
-impl From<OperationOutcome> for OpOutcome {
-    fn from(out: OperationOutcome) -> OpOutcome {
-        match out {
-            OperationOutcome::Success => OpOutcome::Success,
-            OperationOutcome::Skipped => OpOutcome::Skipped,
-            OperationOutcome::SkipRepeat => OpOutcome::SkipRepeat,
-        }
-    }
-}
 /// Different distributed storage clusters have different ways of adding and removing
 /// disks.  This will be consolidated here in trait impl's.
 pub trait Backend {
@@ -38,26 +19,17 @@ pub trait Backend {
     /// For gluster or other services it might be much easier
     /// If simulate is passed no action should be taken
     /// An optional osd_id can be provided to ensure the osd is set to that
-    fn add_disk(
-        &self,
-        device: &Path,
-        id: Option<u64>,
-        simulate: bool,
-    ) -> BynarResult<OperationOutcome>;
+    fn add_disk(&self, device: &Path, id: Option<u64>, simulate: bool) -> BynarResult<OpOutcome>;
 
     /// Remove a disk from a cluster
     /// If simulate is passed no action should be taken
-    fn remove_disk(&self, device: &Path, simulate: bool) -> BynarResult<OperationOutcome>;
+    fn remove_disk(&self, device: &Path, simulate: bool) -> BynarResult<OpOutcome>;
 
     /// Check if it's safe to remove a disk from a cluster
     /// If simulate is passed then this always returns true
     /// Take any actions needed with this call to figure out if a disk is safe
     /// to remove from the cluster.
-    fn safe_to_remove(
-        &self,
-        device: &Path,
-        simulate: bool,
-    ) -> BynarResult<(OperationOutcome, bool)>;
+    fn safe_to_remove(&self, device: &Path, simulate: bool) -> BynarResult<(OpOutcome, bool)>;
 }
 
 /// The supported backend types

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -18,11 +18,11 @@ pub trait Backend {
     /// For gluster or other services it might be much easier
     /// If simulate is passed no action should be taken
     /// An optional osd_id can be provided to ensure the osd is set to that
-    fn add_disk(&self, device: &Path, id: Option<u64>, simulate: bool) -> BynarResult<()>;
+    fn add_disk(&self, device: &Path, id: Option<u64>, simulate: bool) -> BynarResult<bool>;
 
     /// Remove a disk from a cluster
     /// If simulate is passed no action should be taken
-    fn remove_disk(&self, device: &Path, simulate: bool) -> BynarResult<()>;
+    fn remove_disk(&self, device: &Path, simulate: bool) -> BynarResult<bool>;
 
     /// Check if it's safe to remove a disk from a cluster
     /// If simulate is passed then this always returns true

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,16 +9,16 @@ use api::service::Disk;
 use clap::{crate_authors, crate_version, App, Arg, ArgMatches, SubCommand};
 use helpers::error::BynarResult;
 use hostname::get_hostname;
-use log::{error, info,trace};
+use log::{error, info, trace};
 use simplelog::{CombinedLogger, Config, TermLogger, WriteLogger};
 use zmq::Socket;
 /*
     CLI client to call functions over RPC
 */
 
-fn add_disk(s: &Socket, path: &Path, id: Option<u64>, simulate: bool) -> BynarResult<()> {
-    helpers::add_disk_request(s, path, id, simulate)?;
-    Ok(())
+fn add_disk(s: &Socket, path: &Path, id: Option<u64>, simulate: bool) -> BynarResult<bool> {
+    let res = helpers::add_disk_request(s, path, id, simulate)?;
+    Ok(res)
 }
 
 fn list_disks(s: &Socket) -> BynarResult<Vec<Disk>> {
@@ -28,9 +28,9 @@ fn list_disks(s: &Socket) -> BynarResult<Vec<Disk>> {
     Ok(disks)
 }
 
-fn remove_disk(s: &Socket, path: &Path, id: Option<u64>, simulate: bool) -> BynarResult<()> {
-    helpers::remove_disk_request(s, path, id, simulate)?;
-    Ok(())
+fn remove_disk(s: &Socket, path: &Path, id: Option<u64>, simulate: bool) -> BynarResult<bool> {
+    let res = helpers::remove_disk_request(s, path, id, simulate)?;
+    Ok(res)
 }
 
 fn handle_add_disk(s: &Socket, matches: &ArgMatches<'_>) {
@@ -45,8 +45,12 @@ fn handle_add_disk(s: &Socket, matches: &ArgMatches<'_>) {
         None => false,
     };
     match add_disk(s, &p, id, simulate) {
-        Ok(_) => {
-            println!("Adding disk successful");
+        Ok(res) => {
+            if res {
+                println!("Adding disk successful");
+            } else {
+                println!("Disk cannot be added");
+            }
         }
         Err(e) => {
             println!("Adding disk failed: {}", e);
@@ -66,15 +70,12 @@ fn handle_list_disks(s: &Socket) {
     };
 }
 
-fn handle_jira_tickets(s: &Socket) -> BynarResult<()>{
+fn handle_jira_tickets(s: &Socket) -> BynarResult<()> {
     trace!("handle_jira_tickets called");
     let _tickets = helpers::get_jira_tickets(s)?;
     trace!("handle_jira_tickets Finished");
     Ok(())
-   
-   
 }
-
 
 fn handle_remove_disk(s: &Socket, matches: &ArgMatches<'_>) {
     let p = Path::new(matches.value_of("path").unwrap());
@@ -88,8 +89,12 @@ fn handle_remove_disk(s: &Socket, matches: &ArgMatches<'_>) {
         None => false,
     };
     match remove_disk(s, &p, id, simulate) {
-        Ok(_) => {
-            println!("Removing disk successful");
+        Ok(res) => {
+            if res {
+                println!("Removing disk successful");
+            } else {
+                println!("Disk cannot be added");
+            }
         }
         Err(e) => {
             println!("Removing disk failed: {}", e);

--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -177,7 +177,7 @@ fn listen(
                     error!("Remove operation must include disk field.  Ignoring request");
                     continue;
                 }
-                let mut result = OpResult::new();
+                let mut result = OpBoolResult::new();
                 match safe_to_remove(&Path::new(operation.get_disk()), &backend_type, config_dir) {
                     Ok(true) => {
                         match remove_disk(
@@ -197,6 +197,7 @@ fn listen(
                     Ok(false) => {
                         debug!("Disk is not safe to remove");
                         //Response to client
+                        result.set_value(false);
                         result.set_result(ResultType::ERR);
                         result.set_error_msg("Not safe to remove disk".to_string());
                         let _ = respond_to_client(&result, &mut responder);
@@ -204,6 +205,7 @@ fn listen(
                     Err(e) => {
                         error!("safe to remove failed: {:?}", e);
                         // Response to client
+                        result.set_value(false);
                         result.set_result(ResultType::ERR);
                         result.set_error_msg(e.to_string());
                         let _ = respond_to_client(&result, &mut responder);

--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -15,7 +15,7 @@ mod backend;
 mod in_progress;
 mod test_disk;
 
-use crate::backend::{BackendType, OperationOutcome};
+use crate::backend::BackendType;
 use crate::in_progress::create_db_connection_pool;
 use block_utils::{Device, MediaType};
 use clap::{crate_authors, crate_version, App, Arg};
@@ -179,7 +179,7 @@ fn listen(
                 }
                 let mut result = OpOutcomeResult::new();
                 match safe_to_remove(&Path::new(operation.get_disk()), &backend_type, config_dir) {
-                    Ok((OperationOutcome::Success, true)) => {
+                    Ok((OpOutcome::Success, true)) => {
                         match remove_disk(
                             &mut responder,
                             operation.get_disk(),
@@ -194,12 +194,12 @@ fn listen(
                             }
                         };
                     }
-                    Ok((OperationOutcome::Skipped, _)) => {
+                    Ok((OpOutcome::Skipped, _)) => {
                         debug!("Disk skipped");
                         result.set_outcome(OpOutcome::Skipped);
                         result.set_result(ResultType::OK);
                     }
-                    Ok((OperationOutcome::SkipRepeat, _)) => {
+                    Ok((OpOutcome::SkipRepeat, _)) => {
                         debug!("Disk skipped, safe to remove already ran");
                         result.set_outcome(OpOutcome::SkipRepeat);
                         result.set_result(ResultType::OK);
@@ -399,7 +399,7 @@ fn safe_to_remove(
     d: &Path,
     backend: &BackendType,
     config_dir: &Path,
-) -> BynarResult<(OperationOutcome, bool)> {
+) -> BynarResult<(OpOutcome, bool)> {
     let backend = backend::load_backend(backend, Some(config_dir))?;
     let (safe) = backend.safe_to_remove(d, false)?;
 

--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -194,15 +194,19 @@ fn listen(
                             }
                         };
                     }
-                    Ok((OpOutcome::Skipped, _)) => {
+                    Ok((OpOutcome::Skipped, val)) => {
                         debug!("Disk skipped");
                         result.set_outcome(OpOutcome::Skipped);
+                        result.set_value(val);
                         result.set_result(ResultType::OK);
+                        let _ = respond_to_client(&result, &mut responder);
                     }
-                    Ok((OpOutcome::SkipRepeat, _)) => {
+                    Ok((OpOutcome::SkipRepeat, val)) => {
                         debug!("Disk skipped, safe to remove already ran");
                         result.set_outcome(OpOutcome::SkipRepeat);
+                        result.set_value(val);
                         result.set_result(ResultType::OK);
+                        let _ = respond_to_client(&result, &mut responder);
                     }
                     Ok((_, false)) => {
                         debug!("Disk is not safe to remove");

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -5,7 +5,10 @@ use std::fs::read_to_string;
 use std::path::Path;
 
 use crate::error::{BynarError, BynarResult};
-use api::service::{Disk, JiraInfo, Op, OpBoolResult, OpJiraTicketsResult, Operation, ResultType};
+use api::service::{
+    Disk, JiraInfo, Op, OpBoolResult, OpJiraTicketsResult, OpOutcome, OpOutcomeResult, Operation,
+    ResultType,
+};
 use hashicorp_vault::client::VaultClient;
 use log::{debug, error};
 use protobuf::parse_from_bytes;
@@ -58,7 +61,7 @@ pub fn add_disk_request(
     path: &Path,
     id: Option<u64>,
     simulate: bool,
-) -> BynarResult<bool> {
+) -> BynarResult<OpOutcome> {
     let mut o = Operation::new();
     debug!("Creating add disk operation request");
     o.set_Op_type(Op::Add);
@@ -75,9 +78,9 @@ pub fn add_disk_request(
     debug!("Waiting for response");
     let add_response = s.recv_bytes(0)?;
     debug!("Decoding msg len: {}", add_response.len());
-    let op_result = parse_from_bytes::<api::service::OpBoolResult>(&add_response)?;
+    let op_result = parse_from_bytes::<api::service::OpOutcomeResult>(&add_response)?;
     match op_result.get_result() {
-        ResultType::OK => Ok(op_result.get_value()),
+        ResultType::OK => Ok(op_result.get_outcome()),
         ResultType::ERR => {
             if op_result.has_error_msg() {
                 let msg = op_result.get_error_msg();
@@ -137,7 +140,7 @@ pub fn list_disks_request(s: &Socket) -> BynarResult<Vec<Disk>> {
     Ok(d)
 }
 
-pub fn safe_to_remove_request(s: &Socket, path: &Path) -> BynarResult<bool> {
+pub fn safe_to_remove_request(s: &Socket, path: &Path) -> BynarResult<(OpOutcome, bool)> {
     let mut o = Operation::new();
     debug!("Creating safe to remove operation request");
     o.set_Op_type(Op::SafeToRemove);
@@ -149,9 +152,9 @@ pub fn safe_to_remove_request(s: &Socket, path: &Path) -> BynarResult<bool> {
     debug!("Waiting for response");
     let safe_response = s.recv_bytes(0)?;
     debug!("Decoding msg len: {}", safe_response.len());
-    let op_result = parse_from_bytes::<OpBoolResult>(&safe_response)?;
+    let op_result = parse_from_bytes::<OpOutcomeResult>(&safe_response)?;
     match op_result.get_result() {
-        ResultType::OK => Ok(op_result.get_value()),
+        ResultType::OK => Ok((op_result.get_outcome(), op_result.get_value())),
         ResultType::ERR => Err(BynarError::from(op_result.get_error_msg())),
     }
 }
@@ -161,7 +164,7 @@ pub fn remove_disk_request(
     path: &Path,
     id: Option<u64>,
     simulate: bool,
-) -> BynarResult<bool> {
+) -> BynarResult<OpOutcome> {
     let mut o = Operation::new();
     debug!("Creating remove operation request");
     o.set_Op_type(Op::Remove);
@@ -178,7 +181,7 @@ pub fn remove_disk_request(
     debug!("Waiting for response");
     let remove_response = s.recv_bytes(0)?;
     debug!("Decoding msg len: {}", remove_response.len());
-    let op_result = match parse_from_bytes::<api::service::OpBoolResult>(&remove_response) {
+    let op_result = match parse_from_bytes::<api::service::OpOutcomeResult>(&remove_response) {
         Err(e) => {
             error!("Unable to Parse Message {:?}", e);
             return Err(BynarError::from(e));
@@ -186,7 +189,7 @@ pub fn remove_disk_request(
         Ok(o) => o,
     };
     match op_result.get_result() {
-        ResultType::OK => Ok(op_result.get_value()),
+        ResultType::OK => Ok(op_result.get_outcome()),
         ResultType::ERR => {
             if op_result.has_error_msg() {
                 let msg = op_result.get_error_msg();

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -58,7 +58,7 @@ pub fn add_disk_request(
     path: &Path,
     id: Option<u64>,
     simulate: bool,
-) -> BynarResult<()> {
+) -> BynarResult<bool> {
     let mut o = Operation::new();
     debug!("Creating add disk operation request");
     o.set_Op_type(Op::Add);
@@ -75,12 +75,9 @@ pub fn add_disk_request(
     debug!("Waiting for response");
     let add_response = s.recv_bytes(0)?;
     debug!("Decoding msg len: {}", add_response.len());
-    let op_result = parse_from_bytes::<api::service::OpResult>(&add_response)?;
+    let op_result = parse_from_bytes::<api::service::OpBoolResult>(&add_response)?;
     match op_result.get_result() {
-        ResultType::OK => {
-            debug!("Add disk successful");
-            Ok(())
-        }
+        ResultType::OK => Ok(op_result.get_value()),
         ResultType::ERR => {
             if op_result.has_error_msg() {
                 let msg = op_result.get_error_msg();
@@ -164,7 +161,7 @@ pub fn remove_disk_request(
     path: &Path,
     id: Option<u64>,
     simulate: bool,
-) -> BynarResult<()> {
+) -> BynarResult<bool> {
     let mut o = Operation::new();
     debug!("Creating remove operation request");
     o.set_Op_type(Op::Remove);
@@ -181,7 +178,7 @@ pub fn remove_disk_request(
     debug!("Waiting for response");
     let remove_response = s.recv_bytes(0)?;
     debug!("Decoding msg len: {}", remove_response.len());
-    let op_result = match parse_from_bytes::<api::service::OpResult>(&remove_response) {
+    let op_result = match parse_from_bytes::<api::service::OpBoolResult>(&remove_response) {
         Err(e) => {
             error!("Unable to Parse Message {:?}", e);
             return Err(BynarError::from(e));
@@ -189,10 +186,7 @@ pub fn remove_disk_request(
         Ok(o) => o,
     };
     match op_result.get_result() {
-        ResultType::OK => {
-            debug!("Remove disk successful");
-            Ok(())
-        }
+        ResultType::OK => Ok(op_result.get_value()),
         ResultType::ERR => {
             if op_result.has_error_msg() {
                 let msg = op_result.get_error_msg();

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,13 +200,14 @@ fn check_for_failed_disks(
                                     );
 
                                     match helpers::remove_disk_request(
-                                        &socket,
-                                        &dev_path,
-                                        None,
-                                        false,
+                                        &socket, &dev_path, None, false,
                                     ) {
-                                        Ok(_) => {
-                                            debug!("Disk removal successful");
+                                        Ok(res) => {
+                                            if res {
+                                                debug!("Disk removal successful");
+                                            } else {
+                                                error!("Disk is not removable, Disk skipped.");
+                                            }
                                         }
                                         Err(e) => {
                                             error!("Disk removal failed: {}", e);
@@ -407,8 +408,13 @@ fn add_repaired_disks(
                     None,
                     simulate,
                 ) {
-                    Ok(_) => {
-                        debug!("Disk added successfully. Updating database record");
+                    Ok(res) => {
+                        if res {
+                            debug!("Disk added successfully. Updating database record");
+                        } else {
+                            // Disk was either boot or something that shouldn't be added via backend
+                            error!("Disk Skipped.  Updating database record");
+                        }
                         match in_progress::resolve_ticket_in_db(pool, &ticket.ticket_id) {
                             Ok(_) => debug!("Database updated"),
                             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod util;
 use crate::create_support_ticket::{create_support_ticket, ticket_resolved};
 use crate::in_progress::*;
 use crate::test_disk::State;
+use api::service::OpOutcome;
 use clap::{crate_authors, crate_version, App, Arg};
 use helpers::{error::*, host_information::Host, ConfigSettings};
 use log::{debug, error, info, warn};
@@ -187,7 +188,7 @@ fn check_for_failed_disks(
                                 helpers::safe_to_remove_request(&socket, &dev_path),
                                 config.slack_webhook.is_some(),
                             ) {
-                                (Ok(true), true) => {
+                                (Ok((OpOutcome::Success, true)), true) => {
                                     debug!("safe to remove: true");
                                     //Ok to remove the disk
                                     let _ = notify_slack(
@@ -202,19 +203,21 @@ fn check_for_failed_disks(
                                     match helpers::remove_disk_request(
                                         &socket, &dev_path, None, false,
                                     ) {
-                                        Ok(res) => {
-                                            if res {
-                                                debug!("Disk removal successful");
-                                            } else {
-                                                error!("Disk is not removable, Disk skipped.");
+                                        Ok(outcome) => match outcome {
+                                            OpOutcome::Success => debug!("Disk removal successful"),
+                                            OpOutcome::Skipped => {
+                                                debug!("Disk skipped, disk is not removable")
                                             }
-                                        }
+                                            OpOutcome::SkipRepeat => {
+                                                debug!("Disk already removed, skipping.")
+                                            }
+                                        },
                                         Err(e) => {
                                             error!("Disk removal failed: {}", e);
                                         }
                                     };
                                 }
-                                (Ok(false), true) => {
+                                (Ok((_, false)), true) => {
                                     debug!("safe to remove: false");
                                     let _ = notify_slack(
                                         config,
@@ -408,12 +411,17 @@ fn add_repaired_disks(
                     None,
                     simulate,
                 ) {
-                    Ok(res) => {
-                        if res {
-                            debug!("Disk added successfully. Updating database record");
-                        } else {
+                    Ok(outcome) => {
+                        match outcome {
+                            OpOutcome::Success => {
+                                debug!("Disk added successfully. Updating database record")
+                            }
                             // Disk was either boot or something that shouldn't be added via backend
-                            error!("Disk Skipped.  Updating database record");
+                            OpOutcome::Skipped => debug!("Disk Skipped.  Updating database record"),
+                            // Disk is already in the cluster
+                            OpOutcome::SkipRepeat => {
+                                debug!("Disk already added.  Skipping.  Updating database record")
+                            }
                         }
                         match in_progress::resolve_ticket_in_db(pool, &ticket.ticket_id) {
                             Ok(_) => debug!("Database updated"),


### PR DESCRIPTION
Added an attribute to the Ceph Config to filter out non_OSD disks, as well as enhancing the backend function return values to better describe the outcome of the functions for client consumption