### PR TITLE
Single instance

### DIFF
--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -663,7 +663,7 @@ fn main() {
             return;
         }
     }
-    let config = helpers::load_config(config_dir, "disk-manager.json");
+    let config = helpers::load_config::<DiskManagerConfig>(config_dir, "disk-manager.json");
     if let Err(e) = config {
         error!(
             "Failed to load config file {}. error: {}",

--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -689,7 +689,6 @@ fn main() {
                 let out = String::from_utf8_lossy(&output.stdout);
                 if out.contains("disk-manager") {
                     //skip
-                    signals.close();
                     error!("There is already a running instance of disk-manager! Abort!");
                     return;
                 }

--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -689,7 +689,6 @@ fn main() {
         //check if the pidfile exists
         let pidpath = Path::new(&pidfile);
         if pidpath.exists() {
-            trace!("path exists");
             //open pidfile and check if process with pid exists
             let pid = read_to_string(pidpath).expect("Unable to read pid from pidfile");
             let output = Command::new("ps")

--- a/src/main.rs
+++ b/src/main.rs
@@ -533,7 +533,11 @@ fn main() {
     loggers.push(WriteLogger::new(
         level,
         Config::default(),
-        OpenOptions::new().append(true).create(true).open("/var/log/bynar.log").expect("/var/log/bynar.log creation failed"),
+        OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open("/var/log/bynar.log")
+            .expect("/var/log/bynar.log creation failed"),
     ));
     let config_dir = Path::new(matches.value_of("configdir").unwrap());
     if !config_dir.exists() {
@@ -579,8 +583,11 @@ fn main() {
         if pidpath.exists() {
             //open pidfile and check if process with pid exists
             let pid = read_to_string(pidpath).expect("Unable to read pid from pidfile");
-            let output = Command::new("ps").args(&["-p", &pid]).output().expect("Unable to open shell to run ps command");
-            match output.status.code(){
+            let output = Command::new("ps")
+                .args(&["-p", &pid])
+                .output()
+                .expect("Unable to open shell to run ps command");
+            match output.status.code() {
                 Some(0) => {
                     let out = String::from_utf8_lossy(&output.stdout);
                     if out.contains("bynar") {
@@ -592,14 +599,13 @@ fn main() {
                 }
                 _ => {}
             }
-
         }
 
         let stdout = File::create(&outfile).expect(&format!("{} creation failed", outfile));
         let stderr = File::create(&errfile).expect(&format!("{} creation failed", errfile));
 
         trace!("I'm Parent and My pid is {}", process::id());
- 
+
         let daemon = Daemonize::new()
             .pid_file(&pidfile) // Every method except `new` and `start`
             .chown_pid_file(true)
@@ -619,7 +625,7 @@ fn main() {
     } else {
         signals.close();
     }
-    
+
     info!("------------------------------------------------\n\t\tStarting up");
 
     let simulate = matches.is_present("simulate");

--- a/src/main.rs
+++ b/src/main.rs
@@ -620,7 +620,7 @@ fn main() {
         signals.close();
     }
     
-    info!("\n\nStarting up\n");
+    info!("\n------------------------------------------------\nStarting up\n");
 
     let simulate = matches.is_present("simulate");
     let time = matches.value_of("time").unwrap().parse::<u64>().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -566,6 +566,29 @@ fn main() {
     }
     let config: ConfigSettings = config.expect("Failed to load config");
     let _ = CombinedLogger::init(loggers);
+    let pidfile = format!("/var/log/{}", config.daemon_pid);
+    //check if the pidfile exists
+    let pidpath = Path::new(&pidfile);
+    if pidpath.exists() {
+        //open pidfile and check if process with pid exists
+        let pid = read_to_string(pidpath).expect("Unable to read pid from pidfile");
+        let output = Command::new("ps")
+            .args(&["-p", &pid])
+            .output()
+            .expect("Unable to open shell to run ps command");
+        match output.status.code() {
+            Some(0) => {
+                let out = String::from_utf8_lossy(&output.stdout);
+                if out.contains("bynar") {
+                    //skip
+                    signals.close();
+                    error!("There is already a running instance of bynar! Abort!");
+                    return;
+                }
+            }
+            _ => {}
+        }
+    }
     let signals = Signals::new(&[
         signal_hook::SIGHUP,
         signal_hook::SIGTERM,
@@ -577,29 +600,6 @@ fn main() {
     if daemon {
         let outfile = format!("/var/log/{}", config.daemon_output);
         let errfile = format!("/var/log/{}", config.daemon_error);
-        let pidfile = format!("/var/log/{}", config.daemon_pid);
-        //check if the pidfile exists
-        let pidpath = Path::new(&pidfile);
-        if pidpath.exists() {
-            //open pidfile and check if process with pid exists
-            let pid = read_to_string(pidpath).expect("Unable to read pid from pidfile");
-            let output = Command::new("ps")
-                .args(&["-p", &pid])
-                .output()
-                .expect("Unable to open shell to run ps command");
-            match output.status.code() {
-                Some(0) => {
-                    let out = String::from_utf8_lossy(&output.stdout);
-                    if out.contains("bynar") {
-                        //skip
-                        signals.close();
-                        error!("There is already a running instance of bynar! Abort!");
-                        return;
-                    }
-                }
-                _ => {}
-            }
-        }
 
         let stdout = File::create(&outfile).expect(&format!("{} creation failed", outfile));
         let stderr = File::create(&errfile).expect(&format!("{} creation failed", errfile));

--- a/src/main.rs
+++ b/src/main.rs
@@ -620,7 +620,7 @@ fn main() {
         signals.close();
     }
     
-    info!("\n------------------------------------------------\nStarting up\n");
+    info!("------------------------------------------------\n\t\tStarting up");
 
     let simulate = matches.is_present("simulate");
     let time = matches.value_of("time").unwrap().parse::<u64>().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ use slack_hook::{PayloadBuilder, Slack};
 use std::fs::{create_dir, read_to_string, File};
 use std::path::{Path, PathBuf};
 use std::process;
+use std::process::Command;
 use std::time::{Duration, Instant};
 
 /*#[derive(Clone, Debug, Deserialize)]
@@ -573,11 +574,32 @@ fn main() {
         let outfile = format!("/var/log/{}", config.daemon_output);
         let errfile = format!("/var/log/{}", config.daemon_error);
         let pidfile = format!("/var/log/{}", config.daemon_pid);
+        //check if the pidfile exists
+        let pidpath = Path::new(&pidfile);
+        if pidpath.exists() {
+            //open pidfile and check if process with pid exists
+            let pid = read_to_string(pidpath).expect("Unable to read pid from pidfile");
+            let output = Command::new("ps").args(&["-p", &pid]).output().expect("Unable to open shell to run ps command");
+            match output.status.code(){
+                Some(0) => {
+                    let out = String::from_utf8_lossy(&output.stdout);
+                    if out.contains("bynar") {
+                        //skip
+                        signals.close();
+                        error!("There is already a running instance of bynar! Abort!");
+                        return;
+                    }
+                }
+                _ => {}
+            }
+
+        }
+
         let stdout = File::create(&outfile).expect(&format!("{} creation failed", outfile));
         let stderr = File::create(&errfile).expect(&format!("{} creation failed", errfile));
 
         trace!("I'm Parent and My pid is {}", process::id());
-
+ 
         let daemon = Daemonize::new()
             .pid_file(&pidfile) // Every method except `new` and `start`
             .chown_pid_file(true)
@@ -680,7 +702,7 @@ fn main() {
             }
         };
         if daemon {
-            while (now.elapsed() < dur) {
+            while now.elapsed() < dur {
                 for signal in signals.pending() {
                     match signal as c_int {
                         signal_hook::SIGHUP => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -581,7 +581,6 @@ fn main() {
                 let out = String::from_utf8_lossy(&output.stdout);
                 if out.contains("bynar") {
                     //skip
-                    signals.close();
                     error!("There is already a running instance of bynar! Abort!");
                     return;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use signal_hook::iterator::Signals;
 use signal_hook::*;
 use simplelog::{CombinedLogger, Config, SharedLogger, TermLogger, WriteLogger};
 use slack_hook::{PayloadBuilder, Slack};
-use std::fs::{create_dir, read_to_string, File};
+use std::fs::{create_dir, read_to_string, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::process::Command;
@@ -533,7 +533,7 @@ fn main() {
     loggers.push(WriteLogger::new(
         level,
         Config::default(),
-        File::create("/var/log/bynar.log").expect("/var/log/bynar.log creation failed"),
+        OpenOptions::new().append(true).create(true).open("/var/log/bynar.log").expect("/var/log/bynar.log creation failed"),
     ));
     let config_dir = Path::new(matches.value_of("configdir").unwrap());
     if !config_dir.exists() {
@@ -619,7 +619,8 @@ fn main() {
     } else {
         signals.close();
     }
-    info!("Starting up");
+    
+    info!("\n\nStarting up\n");
 
     let simulate = matches.is_present("simulate");
     let time = matches.value_of("time").unwrap().parse::<u64>().unwrap();


### PR DESCRIPTION
When a process has been daemonized, any subsequent calls to run the process should abort (there should be only one instance of a daemon process running).  So if disk-manager/bynar is running as a daemon, another process cannot be spun up until the current process is killed.